### PR TITLE
Translate "Name" and "Time" header in ghost menu

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1007,8 +1007,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 	static CColumn s_aCols[] = {
 		{-1, " ", 2.0f, {0}, {0}},
 		{COL_ACTIVE, " ", 30.0f, {0}, {0}},
-		{COL_NAME, "Name", 300.0f, {0}, {0}},
-		{COL_TIME, "Time", 200.0f, {0}, {0}},
+		{COL_NAME, "Name", 300.0f, {0}, {0}}, // Localize("Name")
+		{COL_TIME, "Time", 200.0f, {0}, {0}}, // Localize("Time")
 	};
 
 	int NumCols = sizeof(s_aCols) / sizeof(CColumn);
@@ -1024,7 +1024,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	// do headers
 	for(int i = 0; i < NumCols; i++)
-		DoButton_GridHeader(s_aCols[i].m_Caption, s_aCols[i].m_Caption, 0, &s_aCols[i].m_Rect);
+		DoButton_GridHeader(s_aCols[i].m_Caption, Localize(s_aCols[i].m_Caption), 0, &s_aCols[i].m_Rect);
 
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3797859/121635764-66f49e80-cab9-11eb-8b16-819d21961e84.png)

These two headers weren't translated.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
